### PR TITLE
Fix Bootstrap import

### DIFF
--- a/scss/sleek.scss
+++ b/scss/sleek.scss
@@ -1,6 +1,6 @@
 @import 'variables';
 
-@import "../node_modules/bootstrap/scss/bootstrap.scss";
+@import "~bootstrap/scss/bootstrap.scss";
 
 @import 'reboot';
 @import 'utilities/spacing';


### PR DESCRIPTION
Fix Bootstrap import.
With this path the sass-loader not find the package.

@import "../node_modules/bootstrap/scss/bootstrap.scss";
       ^
      Can't find stylesheet to import.

Fixes #298